### PR TITLE
Stack overflow

### DIFF
--- a/builder/src/common.rs
+++ b/builder/src/common.rs
@@ -1,5 +1,7 @@
+use std::boxed::{ Box };
 use std::cmp::{ Ordering };
 use std::collections::{ HashMap, HashSet };
+use std::rc::{ Rc }; 
 use serde::{ Deserialize, Serialize };
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/builder/src/common.rs
+++ b/builder/src/common.rs
@@ -1,7 +1,5 @@
-use std::boxed::{ Box };
 use std::cmp::{ Ordering };
 use std::collections::{ HashMap, HashSet };
-use std::rc::{ Rc }; 
 use serde::{ Deserialize, Serialize };
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/builder/src/slate_reader.rs
+++ b/builder/src/slate_reader.rs
@@ -1,5 +1,7 @@
+use std::boxed::{ Box };
 use std::collections::{ HashMap, HashSet };
 use std::error::Error;
+use std::rc::{ Rc };
 use csv;
 use serde::{ Deserialize, Serialize };
 use crate::common::{ BuilderState, Player };


### PR DESCRIPTION
reducing memory usage of optimize algorithm by using Rc<RefCell<Vec<u32>>> for category list instead of cloning it whenever its needed and also removing players with 0 projected points from the player pool. Currently tested on a computer with 4GB of RAM. might be able to go lower.